### PR TITLE
Adjust a couple of the default challenges to be more consistent.

### DIFF
--- a/challenges/library/default-ru.json
+++ b/challenges/library/default-ru.json
@@ -2374,7 +2374,7 @@
             "GHAST": 1
           },
           "removeEntities": false,
-          "searchRadius": 10,
+          "searchRadius": 20,
           "requiredPermissions": []
         }
       },

--- a/challenges/library/default-ru.json
+++ b/challenges/library/default-ru.json
@@ -1491,7 +1491,7 @@
           "requiredItems": [
             "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 1976\n  type: WHITE_WOOL\n  amount: 16\n",
             "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 1976\n  type: YELLOW_WOOL\n  amount: 16\n",
-            "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 1976\n  type: RED_WOOL\n  amount: 8\n",
+            "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 1976\n  type: RED_WOOL\n  amount: 16\n",
             "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 1976\n  type: PURPLE_WOOL\n  amount: 16\n",
             "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 1976\n  type: PINK_WOOL\n  amount: 16\n",
             "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 1976\n  type: ORANGE_WOOL\n  amount: 16\n",

--- a/challenges/library/default-zh-CN.json
+++ b/challenges/library/default-zh-CN.json
@@ -1493,7 +1493,7 @@
           "requiredItems": [
             "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 1976\n  type: WHITE_WOOL\n  amount: 16\n",
             "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 1976\n  type: YELLOW_WOOL\n  amount: 16\n",
-            "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 1976\n  type: RED_WOOL\n  amount: 8\n",
+            "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 1976\n  type: RED_WOOL\n  amount: 16\n",
             "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 1976\n  type: PURPLE_WOOL\n  amount: 16\n",
             "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 1976\n  type: PINK_WOOL\n  amount: 16\n",
             "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 1976\n  type: ORANGE_WOOL\n  amount: 16\n",

--- a/challenges/library/default-zh-CN.json
+++ b/challenges/library/default-zh-CN.json
@@ -2376,7 +2376,7 @@
             "GHAST": 1
           },
           "removeEntities": false,
-          "searchRadius": 10,
+          "searchRadius": 20,
           "requiredPermissions": []
         }
       },

--- a/challenges/library/default.json
+++ b/challenges/library/default.json
@@ -2374,7 +2374,7 @@
             "GHAST": 1
           },
           "removeEntities": false,
-          "searchRadius": 10,
+          "searchRadius": 20,
           "requiredPermissions": []
         }
       },

--- a/challenges/library/default.json
+++ b/challenges/library/default.json
@@ -1491,7 +1491,7 @@
           "requiredItems": [
             "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 1976\n  type: WHITE_WOOL\n  amount: 16\n",
             "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 1976\n  type: YELLOW_WOOL\n  amount: 16\n",
-            "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 1976\n  type: RED_WOOL\n  amount: 8\n",
+            "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 1976\n  type: RED_WOOL\n  amount: 16\n",
             "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 1976\n  type: PURPLE_WOOL\n  amount: 16\n",
             "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 1976\n  type: PINK_WOOL\n  amount: 16\n",
             "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 1976\n  type: ORANGE_WOOL\n  amount: 16\n",


### PR DESCRIPTION
The 'Wool Collector' challenge has a different amount for red wool (8) required when compared to every other type of wool (16).

The hostile mob farm has a smaller radius of 10, when compared to the water, and passive mob zoos which both have a radius of 20.

Thanks for considering.