### PR TITLE
Fix description field type in translated Poseidon library files

### DIFF
--- a/challenges/library/poseidon-de.json
+++ b/challenges/library/poseidon-de.json
@@ -4,7 +4,9 @@
       "uniqueId": "opportunity_knocks",
       "friendlyName": "Gelegenheit klopft an",
       "deployed": true,
-      "description": "Hey! Ein Wanderhändler! Schnell, erfülle diese Herausforderung!",
+      "description": [
+        "Hey! Ein Wanderhändler! Schnell, erfülle diese Herausforderung!"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: RED_CARPET\n",
       "order": -1,
       "challengeType": "ISLAND_TYPE",
@@ -50,7 +52,9 @@
       "uniqueId": "adv",
       "friendlyName": "Wegwerfen",
       "deployed": true,
-      "description": "Schließe den Fortschritt „Wegwerfen\" ab",
+      "description": [
+        "Schließe den Fortschritt „Wegwerfen\" ab"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: TRIDENT\n",
       "order": -1,
       "challengeType": "OTHER_TYPE",
@@ -97,7 +101,9 @@
       "uniqueId": "kelp_jerky",
       "friendlyName": "Kelprucken",
       "deployed": true,
-      "description": "Stelle 5 Packungen getrockneten Kelp her",
+      "description": [
+        "Stelle 5 Packungen getrockneten Kelp her"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: DRIED_KELP_BLOCK\n",
       "order": -1,
       "challengeType": "INVENTORY_TYPE",
@@ -141,7 +147,9 @@
       "uniqueId": "squid_hunter",
       "friendlyName": "Surf und Turf",
       "deployed": true,
-      "description": "Besiege Tintenfische und Tropenfische",
+      "description": [
+        "Besiege Tintenfische und Tropenfische"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: TROPICAL_FISH\n",
       "order": -1,
       "challengeType": "STATISTIC_TYPE",
@@ -197,7 +205,9 @@
       "uniqueId": "treasure_hunter",
       "friendlyName": "Mit den Fischen schlafen",
       "deployed": true,
-      "description": "Schlafe in einem Bett",
+      "description": [
+        "Schlafe in einem Bett"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: GREEN_BED\n",
       "order": -1,
       "challengeType": "STATISTIC_TYPE",
@@ -248,7 +258,9 @@
       "uniqueId": "kelp_harvester",
       "friendlyName": "Kelpernter",
       "deployed": true,
-      "description": "Ernte 50 Kelp",
+      "description": [
+        "Ernte 50 Kelp"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: KELP\n",
       "order": 1,
       "challengeType": "INVENTORY_TYPE",
@@ -291,7 +303,9 @@
       "uniqueId": "seagrass_farmer",
       "friendlyName": "Seegras-Bauer",
       "deployed": true,
-      "description": "Sammle Seegras",
+      "description": [
+        "Sammle Seegras"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: SEAGRASS\n",
       "order": 2,
       "challengeType": "INVENTORY_TYPE",
@@ -382,7 +396,9 @@
       "uniqueId": "realm_builder",
       "friendlyName": "Reich-Erbauer",
       "deployed": true,
-      "description": "Verbessere dein Reich auf Level 10 (/[label] level)",
+      "description": [
+        "Verbessere dein Reich auf Level 10 (/[label] level)"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: BRICKS\n",
       "order": 4,
       "challengeType": "OTHER_TYPE",
@@ -425,7 +441,9 @@
       "uniqueId": "sea_sculptor",
       "friendlyName": "Versteck",
       "deployed": true,
-      "description": "Errichte eine Heimatbasis",
+      "description": [
+        "Errichte eine Heimatbasis"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: RED_BED\n",
       "order": 5,
       "challengeType": "ISLAND_TYPE",
@@ -477,7 +495,9 @@
       "uniqueId": "fisher",
       "friendlyName": "Fischer",
       "deployed": true,
-      "description": "Fange 10 Kabeljau",
+      "description": [
+        "Fange 10 Kabeljau"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: COD\n",
       "order": 6,
       "challengeType": "INVENTORY_TYPE",
@@ -564,7 +584,9 @@
       "uniqueId": "shell_harvester",
       "friendlyName": "Muschelsammler",
       "deployed": true,
-      "description": "Sammle 5 Schildkrötenpanzer-Schuppen",
+      "description": [
+        "Sammle 5 Schildkrötenpanzer-Schuppen"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: TURTLE_HELMET\n",
       "order": -1,
       "challengeType": "INVENTORY_TYPE",
@@ -607,7 +629,9 @@
       "uniqueId": "swim_meet",
       "friendlyName": "Schwimmtreffen",
       "deployed": true,
-      "description": "Feiere mit deinen neuen „Freunden\"!",
+      "description": [
+        "Feiere mit deinen neuen „Freunden\"!"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: PLAYER_HEAD\n",
       "order": -1,
       "challengeType": "ISLAND_TYPE",
@@ -700,7 +724,9 @@
       "uniqueId": "dark_food",
       "friendlyName": "Dunkle Nahrung",
       "deployed": true,
-      "description": "Stelle Pilzeintopf her!",
+      "description": [
+        "Stelle Pilzeintopf her!"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: MUSHROOM_STEW\n",
       "order": 1,
       "challengeType": "INVENTORY_TYPE",
@@ -758,7 +784,9 @@
       "uniqueId": "guardian_fighter",
       "friendlyName": "Wächter-Kämpfer",
       "deployed": true,
-      "description": "Besiege 3 Wächter",
+      "description": [
+        "Besiege 3 Wächter"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: PRISMARINE\n",
       "order": 2,
       "challengeType": "STATISTIC_TYPE",
@@ -808,7 +836,9 @@
       "uniqueId": "underwater_farmer",
       "friendlyName": "Unterwasser-Bauer",
       "deployed": true,
-      "description": "Züchte und ernte Seegurken!",
+      "description": [
+        "Züchte und ernte Seegurken!"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: SEA_PICKLE\n",
       "order": 3,
       "challengeType": "INVENTORY_TYPE",
@@ -860,7 +890,9 @@
       "uniqueId": "dryworld_hunter",
       "friendlyName": "Trockenwelt-Jäger",
       "deployed": true,
-      "description": "Töte 10 Creeper, Zombies und Skelette",
+      "description": [
+        "Töte 10 Creeper, Zombies und Skelette"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: IRON_SWORD\n",
       "order": 4,
       "challengeType": "STATISTIC_TYPE",
@@ -924,7 +956,9 @@
       "uniqueId": "abyssal_treasure",
       "friendlyName": "Naturphänomen",
       "deployed": true,
-      "description": "Lass mindestens 1 Block deines Reiches von Schnee bedeckt sein!",
+      "description": [
+        "Lass mindestens 1 Block deines Reiches von Schnee bedeckt sein!"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: SNOW\n",
       "order": -1,
       "challengeType": "ISLAND_TYPE",
@@ -971,7 +1005,9 @@
       "uniqueId": "conch_collector",
       "friendlyName": "Muschelschnecken-Sammler",
       "deployed": true,
-      "description": "Finde und sammle 5 Nautilusmuscheln",
+      "description": [
+        "Finde und sammle 5 Nautilusmuscheln"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: NAUTILUS_SHELL\n",
       "order": -1,
       "challengeType": "INVENTORY_TYPE",
@@ -1012,7 +1048,9 @@
       "uniqueId": "conduit_crafter",
       "friendlyName": "Leitungs-Handwerker",
       "deployed": true,
-      "description": "Fertige einen Leitungsblock an und aktiviere ihn",
+      "description": [
+        "Fertige einen Leitungsblock an und aktiviere ihn"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: CONDUIT\n",
       "order": -1,
       "challengeType": "ISLAND_TYPE",
@@ -1058,7 +1096,9 @@
       "uniqueId": "sea_lantern_artisan",
       "friendlyName": "Meereslaterne-Handwerker",
       "deployed": true,
-      "description": "Fertige 16 Meerlaternen an",
+      "description": [
+        "Fertige 16 Meerlaternen an"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: SEA_LANTERN\n",
       "order": -1,
       "challengeType": "INVENTORY_TYPE",
@@ -1099,7 +1139,9 @@
       "uniqueId": "swimmer",
       "friendlyName": "Poseidons Kuss",
       "deployed": true,
-      "description": "Schwimme 10.000 Blöcke",
+      "description": [
+        "Schwimme 10.000 Blöcke"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: LIGHT_BLUE_GLAZED_TERRACOTTA\n",
       "order": -1,
       "challengeType": "STATISTIC_TYPE",
@@ -1151,7 +1193,9 @@
       "uniqueId": "trawler",
       "friendlyName": "Trawler",
       "deployed": true,
-      "description": "Fange 50 Fische",
+      "description": [
+        "Fange 50 Fische"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: COD\n",
       "order": -1,
       "challengeType": "STATISTIC_TYPE",
@@ -1203,7 +1247,9 @@
       "uniqueId": "trial_step",
       "friendlyName": "Prüfungsschritt",
       "deployed": true,
-      "description": "Betrete eine Prüfungskammer",
+      "description": [
+        "Betrete eine Prüfungskammer"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: TRIAL_KEY\n",
       "order": -1,
       "challengeType": "OTHER_TYPE",
@@ -1249,7 +1295,9 @@
       "uniqueId": "trident_wielder",
       "friendlyName": "Dreizack-Schwinger",
       "deployed": true,
-      "description": "Entferne 10 Ertrunkene aus deinem Reich",
+      "description": [
+        "Entferne 10 Ertrunkene aus deinem Reich"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: TRIDENT\n",
       "order": -1,
       "challengeType": "STATISTIC_TYPE",
@@ -1346,7 +1394,9 @@
       "uniqueId": "my_precious",
       "friendlyName": "Mein Schatz",
       "deployed": true,
-      "description": "Ein paar Eisensachen",
+      "description": [
+        "Ein paar Eisensachen"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: POPPY\n",
       "order": -1,
       "challengeType": "ISLAND_TYPE",
@@ -1396,7 +1446,9 @@
       "uniqueId": "nether_swimmer",
       "friendlyName": "Pionier",
       "deployed": true,
-      "description": "Stelle einen Kompass und eine Uhr her, reise in den Nether und sammle eine Ghast-Träne und einige Blöcke",
+      "description": [
+        "Stelle einen Kompass und eine Uhr her, reise in den Nether und sammle eine Ghast-Träne und einige Blöcke"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: POWERED_RAIL\n",
       "order": -1,
       "challengeType": "INVENTORY_TYPE",
@@ -1444,7 +1496,9 @@
       "uniqueId": "sea_potions",
       "friendlyName": "Meer-Tränke",
       "deployed": true,
-      "description": "Braue einige Tränke",
+      "description": [
+        "Braue einige Tränke"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: POTION\n  meta:\n    ==: ItemMeta\n    meta-type: POTION\n    potion-type: minecraft:harming\n",
       "order": -1,
       "challengeType": "INVENTORY_TYPE",
@@ -1494,7 +1548,9 @@
       "uniqueId": "underwater_empire",
       "friendlyName": "Unterwasser-Imperium",
       "deployed": true,
-      "description": "Baue ein Unterwasser-Imperium mit mindestens 64 Glasblöcken",
+      "description": [
+        "Baue ein Unterwasser-Imperium mit mindestens 64 Glasblöcken"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: GLASS\n",
       "order": -1,
       "challengeType": "ISLAND_TYPE",
@@ -1560,7 +1616,9 @@
       "uniqueId": "guardian_commander",
       "friendlyName": "Wächter-Kommandant",
       "deployed": true,
-      "description": "Besiege 20 Älteste Wächter",
+      "description": [
+        "Besiege 20 Älteste Wächter"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: PRISMARINE_BRICKS\n",
       "order": -1,
       "challengeType": "STATISTIC_TYPE",
@@ -1620,7 +1678,9 @@
       "uniqueId": "statistic_challenge",
       "friendlyName": "Poseidons Vermächtnis",
       "deployed": true,
-      "description": "Fertige einen Leuchtturm an",
+      "description": [
+        "Fertige einen Leuchtturm an"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: BEACON\n",
       "order": -1,
       "challengeType": "STATISTIC_TYPE",
@@ -1670,7 +1730,9 @@
       "uniqueId": "ttt",
       "friendlyName": "Korallen-Legende",
       "deployed": true,
-      "description": "Baue eine riesige Korallenriff-Struktur mit 200 Korallen-Blöcken",
+      "description": [
+        "Baue eine riesige Korallenriff-Struktur mit 200 Korallen-Blöcken"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: BRAIN_CORAL\n",
       "order": -1,
       "challengeType": "ISLAND_TYPE",

--- a/challenges/library/poseidon-es.json
+++ b/challenges/library/poseidon-es.json
@@ -4,7 +4,9 @@
       "uniqueId": "opportunity_knocks",
       "friendlyName": "Llaman a la puerta",
       "deployed": true,
-      "description": "¡Mira! ¡Un comerciante ambulante! ¡Rápido, completa este desafío!",
+      "description": [
+        "¡Mira! ¡Un comerciante ambulante! ¡Rápido, completa este desafío!"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: RED_CARPET\n",
       "order": -1,
       "challengeType": "ISLAND_TYPE",
@@ -50,7 +52,9 @@
       "uniqueId": "adv",
       "friendlyName": "Tirar y olvidar",
       "deployed": true,
-      "description": "Completa el avance \"Tirar y olvidar\"",
+      "description": [
+        "Completa el avance \"Tirar y olvidar\""
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: TRIDENT\n",
       "order": -1,
       "challengeType": "OTHER_TYPE",
@@ -97,7 +101,9 @@
       "uniqueId": "kelp_jerky",
       "friendlyName": "Kelp seco",
       "deployed": true,
-      "description": "Fabrica 5 paquetes de kelp seco",
+      "description": [
+        "Fabrica 5 paquetes de kelp seco"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: DRIED_KELP_BLOCK\n",
       "order": -1,
       "challengeType": "INVENTORY_TYPE",
@@ -141,7 +147,9 @@
       "uniqueId": "squid_hunter",
       "friendlyName": "Mar y tierra",
       "deployed": true,
-      "description": "Elimina calamares y peces tropicales",
+      "description": [
+        "Elimina calamares y peces tropicales"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: TROPICAL_FISH\n",
       "order": -1,
       "challengeType": "STATISTIC_TYPE",
@@ -197,7 +205,9 @@
       "uniqueId": "treasure_hunter",
       "friendlyName": "Dormir con los peces",
       "deployed": true,
-      "description": "Duerme en una cama",
+      "description": [
+        "Duerme en una cama"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: GREEN_BED\n",
       "order": -1,
       "challengeType": "STATISTIC_TYPE",
@@ -248,7 +258,9 @@
       "uniqueId": "kelp_harvester",
       "friendlyName": "Recolector de kelp",
       "deployed": true,
-      "description": "Cosecha 50 kelpas",
+      "description": [
+        "Cosecha 50 kelpas"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: KELP\n",
       "order": 1,
       "challengeType": "INVENTORY_TYPE",
@@ -291,7 +303,9 @@
       "uniqueId": "seagrass_farmer",
       "friendlyName": "Granjero de algas",
       "deployed": true,
-      "description": "Recoge algas marinas",
+      "description": [
+        "Recoge algas marinas"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: SEAGRASS\n",
       "order": 2,
       "challengeType": "INVENTORY_TYPE",
@@ -382,7 +396,9 @@
       "uniqueId": "realm_builder",
       "friendlyName": "Constructor de reinos",
       "deployed": true,
-      "description": "Mejora tu reino al nivel 10 (/[label] level)",
+      "description": [
+        "Mejora tu reino al nivel 10 (/[label] level)"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: BRICKS\n",
       "order": 4,
       "challengeType": "OTHER_TYPE",
@@ -425,7 +441,9 @@
       "uniqueId": "sea_sculptor",
       "friendlyName": "Escondite",
       "deployed": true,
-      "description": "Construye una base de operaciones",
+      "description": [
+        "Construye una base de operaciones"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: RED_BED\n",
       "order": 5,
       "challengeType": "ISLAND_TYPE",
@@ -477,7 +495,9 @@
       "uniqueId": "fisher",
       "friendlyName": "Pescador",
       "deployed": true,
-      "description": "Pesca 10 bacalaos",
+      "description": [
+        "Pesca 10 bacalaos"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: COD\n",
       "order": 6,
       "challengeType": "INVENTORY_TYPE",
@@ -564,7 +584,9 @@
       "uniqueId": "shell_harvester",
       "friendlyName": "Recolector de conchas",
       "deployed": true,
-      "description": "Recoge 5 escamas de caparazón de tortuga",
+      "description": [
+        "Recoge 5 escamas de caparazón de tortuga"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: TURTLE_HELMET\n",
       "order": -1,
       "challengeType": "INVENTORY_TYPE",
@@ -607,7 +629,9 @@
       "uniqueId": "swim_meet",
       "friendlyName": "Encuentro de natación",
       "deployed": true,
-      "description": "¡Celebra una fiesta con tus nuevos \"amigos\"!",
+      "description": [
+        "¡Celebra una fiesta con tus nuevos \"amigos\"!"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: PLAYER_HEAD\n",
       "order": -1,
       "challengeType": "ISLAND_TYPE",
@@ -700,7 +724,9 @@
       "uniqueId": "dark_food",
       "friendlyName": "Comida oscura",
       "deployed": true,
-      "description": "¡Prepara un estofado de hongos!",
+      "description": [
+        "¡Prepara un estofado de hongos!"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: MUSHROOM_STEW\n",
       "order": 1,
       "challengeType": "INVENTORY_TYPE",
@@ -758,7 +784,9 @@
       "uniqueId": "guardian_fighter",
       "friendlyName": "Luchador de guardianes",
       "deployed": true,
-      "description": "Derrota a 3 guardianes",
+      "description": [
+        "Derrota a 3 guardianes"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: PRISMARINE\n",
       "order": 2,
       "challengeType": "STATISTIC_TYPE",
@@ -808,7 +836,9 @@
       "uniqueId": "underwater_farmer",
       "friendlyName": "Granjero submarino",
       "deployed": true,
-      "description": "¡Cultiva y cosecha pepinillos de mar!",
+      "description": [
+        "¡Cultiva y cosecha pepinillos de mar!"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: SEA_PICKLE\n",
       "order": 3,
       "challengeType": "INVENTORY_TYPE",
@@ -860,7 +890,9 @@
       "uniqueId": "dryworld_hunter",
       "friendlyName": "Cazador del mundo seco",
       "deployed": true,
-      "description": "Mata 10 creepers, zombis y esqueletos",
+      "description": [
+        "Mata 10 creepers, zombis y esqueletos"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: IRON_SWORD\n",
       "order": 4,
       "challengeType": "STATISTIC_TYPE",
@@ -924,7 +956,9 @@
       "uniqueId": "abyssal_treasure",
       "friendlyName": "Fenómeno natural",
       "deployed": true,
-      "description": "¡Haz que al menos 1 bloque de tu reino esté cubierto de nieve!",
+      "description": [
+        "¡Haz que al menos 1 bloque de tu reino esté cubierto de nieve!"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: SNOW\n",
       "order": -1,
       "challengeType": "ISLAND_TYPE",
@@ -971,7 +1005,9 @@
       "uniqueId": "conch_collector",
       "friendlyName": "Coleccionista de caracolas",
       "deployed": true,
-      "description": "Encuentra y reúne 5 conchas de nautilo",
+      "description": [
+        "Encuentra y reúne 5 conchas de nautilo"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: NAUTILUS_SHELL\n",
       "order": -1,
       "challengeType": "INVENTORY_TYPE",
@@ -1012,7 +1048,9 @@
       "uniqueId": "conduit_crafter",
       "friendlyName": "Artesano de conductos",
       "deployed": true,
-      "description": "Fabrica y activa un conducto",
+      "description": [
+        "Fabrica y activa un conducto"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: CONDUIT\n",
       "order": -1,
       "challengeType": "ISLAND_TYPE",
@@ -1058,7 +1096,9 @@
       "uniqueId": "sea_lantern_artisan",
       "friendlyName": "Artesano de linternas marinas",
       "deployed": true,
-      "description": "Fabrica 16 linternas marinas",
+      "description": [
+        "Fabrica 16 linternas marinas"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: SEA_LANTERN\n",
       "order": -1,
       "challengeType": "INVENTORY_TYPE",
@@ -1099,7 +1139,9 @@
       "uniqueId": "swimmer",
       "friendlyName": "El beso de Poseidón",
       "deployed": true,
-      "description": "Nada 10.000 bloques",
+      "description": [
+        "Nada 10.000 bloques"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: LIGHT_BLUE_GLAZED_TERRACOTTA\n",
       "order": -1,
       "challengeType": "STATISTIC_TYPE",
@@ -1151,7 +1193,9 @@
       "uniqueId": "trawler",
       "friendlyName": "Arrastrero",
       "deployed": true,
-      "description": "Pesca 50 peces",
+      "description": [
+        "Pesca 50 peces"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: COD\n",
       "order": -1,
       "challengeType": "STATISTIC_TYPE",
@@ -1203,7 +1247,9 @@
       "uniqueId": "trial_step",
       "friendlyName": "Paso de prueba",
       "deployed": true,
-      "description": "Entra en una cámara de prueba",
+      "description": [
+        "Entra en una cámara de prueba"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: TRIAL_KEY\n",
       "order": -1,
       "challengeType": "OTHER_TYPE",
@@ -1249,7 +1295,9 @@
       "uniqueId": "trident_wielder",
       "friendlyName": "Portador del tridente",
       "deployed": true,
-      "description": "Elimina 10 ahogados de tu reino",
+      "description": [
+        "Elimina 10 ahogados de tu reino"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: TRIDENT\n",
       "order": -1,
       "challengeType": "STATISTIC_TYPE",
@@ -1346,7 +1394,9 @@
       "uniqueId": "my_precious",
       "friendlyName": "Mi tesoro",
       "deployed": true,
-      "description": "Algunas cosas de hierro",
+      "description": [
+        "Algunas cosas de hierro"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: POPPY\n",
       "order": -1,
       "challengeType": "ISLAND_TYPE",
@@ -1396,7 +1446,9 @@
       "uniqueId": "nether_swimmer",
       "friendlyName": "Pionero",
       "deployed": true,
-      "description": "Fabrica una brújula y un reloj, viaja al Nether y recoge una lágrima de ghast y algunos bloques",
+      "description": [
+        "Fabrica una brújula y un reloj, viaja al Nether y recoge una lágrima de ghast y algunos bloques"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: POWERED_RAIL\n",
       "order": -1,
       "challengeType": "INVENTORY_TYPE",
@@ -1444,7 +1496,9 @@
       "uniqueId": "sea_potions",
       "friendlyName": "Pociones marinas",
       "deployed": true,
-      "description": "Elabora algunas pociones",
+      "description": [
+        "Elabora algunas pociones"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: POTION\n  meta:\n    ==: ItemMeta\n    meta-type: POTION\n    potion-type: minecraft:harming\n",
       "order": -1,
       "challengeType": "INVENTORY_TYPE",
@@ -1494,7 +1548,9 @@
       "uniqueId": "underwater_empire",
       "friendlyName": "Imperio submarino",
       "deployed": true,
-      "description": "Construye un imperio submarino con al menos 64 bloques de vidrio",
+      "description": [
+        "Construye un imperio submarino con al menos 64 bloques de vidrio"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: GLASS\n",
       "order": -1,
       "challengeType": "ISLAND_TYPE",
@@ -1560,7 +1616,9 @@
       "uniqueId": "guardian_commander",
       "friendlyName": "Comandante de guardianes",
       "deployed": true,
-      "description": "Derrota a 20 guardianes mayores",
+      "description": [
+        "Derrota a 20 guardianes mayores"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: PRISMARINE_BRICKS\n",
       "order": -1,
       "challengeType": "STATISTIC_TYPE",
@@ -1620,7 +1678,9 @@
       "uniqueId": "statistic_challenge",
       "friendlyName": "El legado de Poseidón",
       "deployed": true,
-      "description": "Fabrica un baliza",
+      "description": [
+        "Fabrica un baliza"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: BEACON\n",
       "order": -1,
       "challengeType": "STATISTIC_TYPE",
@@ -1670,7 +1730,9 @@
       "uniqueId": "ttt",
       "friendlyName": "Leyenda del coral",
       "deployed": true,
-      "description": "Construye una enorme estructura de arrecife de coral con 200 bloques de coral",
+      "description": [
+        "Construye una enorme estructura de arrecife de coral con 200 bloques de coral"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: BRAIN_CORAL\n",
       "order": -1,
       "challengeType": "ISLAND_TYPE",

--- a/challenges/library/poseidon-fr.json
+++ b/challenges/library/poseidon-fr.json
@@ -4,7 +4,9 @@
       "uniqueId": "opportunity_knocks",
       "friendlyName": "L'occasion se présente",
       "deployed": true,
-      "description": "Hey ! Un marchand ambulant ! Vite, accomplis ce défi !",
+      "description": [
+        "Hey ! Un marchand ambulant ! Vite, accomplis ce défi !"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: RED_CARPET\n",
       "order": -1,
       "challengeType": "ISLAND_TYPE",
@@ -50,7 +52,9 @@
       "uniqueId": "adv",
       "friendlyName": "Jeter",
       "deployed": true,
-      "description": "Accomplis le progrès \"Jeter\"",
+      "description": [
+        "Accomplis le progrès \"Jeter\""
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: TRIDENT\n",
       "order": -1,
       "challengeType": "OTHER_TYPE",
@@ -97,7 +101,9 @@
       "uniqueId": "kelp_jerky",
       "friendlyName": "Varech séché",
       "deployed": true,
-      "description": "Fabrique 5 paquets de varech séché",
+      "description": [
+        "Fabrique 5 paquets de varech séché"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: DRIED_KELP_BLOCK\n",
       "order": -1,
       "challengeType": "INVENTORY_TYPE",
@@ -141,7 +147,9 @@
       "uniqueId": "squid_hunter",
       "friendlyName": "Mer et terre",
       "deployed": true,
-      "description": "Élimine des calmars et des poissons tropicaux",
+      "description": [
+        "Élimine des calmars et des poissons tropicaux"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: TROPICAL_FISH\n",
       "order": -1,
       "challengeType": "STATISTIC_TYPE",
@@ -197,7 +205,9 @@
       "uniqueId": "treasure_hunter",
       "friendlyName": "Dormir avec les poissons",
       "deployed": true,
-      "description": "Dors dans un lit",
+      "description": [
+        "Dors dans un lit"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: GREEN_BED\n",
       "order": -1,
       "challengeType": "STATISTIC_TYPE",
@@ -248,7 +258,9 @@
       "uniqueId": "kelp_harvester",
       "friendlyName": "Récolteur de varech",
       "deployed": true,
-      "description": "Récolte 50 varechs",
+      "description": [
+        "Récolte 50 varechs"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: KELP\n",
       "order": 1,
       "challengeType": "INVENTORY_TYPE",
@@ -291,7 +303,9 @@
       "uniqueId": "seagrass_farmer",
       "friendlyName": "Cultivateur d'herbes marines",
       "deployed": true,
-      "description": "Collecte des herbes marines",
+      "description": [
+        "Collecte des herbes marines"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: SEAGRASS\n",
       "order": 2,
       "challengeType": "INVENTORY_TYPE",
@@ -382,7 +396,9 @@
       "uniqueId": "realm_builder",
       "friendlyName": "Constructeur de royaume",
       "deployed": true,
-      "description": "Améliore ton royaume au niveau 10 (/[label] level)",
+      "description": [
+        "Améliore ton royaume au niveau 10 (/[label] level)"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: BRICKS\n",
       "order": 4,
       "challengeType": "OTHER_TYPE",
@@ -425,7 +441,9 @@
       "uniqueId": "sea_sculptor",
       "friendlyName": "Cachette",
       "deployed": true,
-      "description": "Établis une base",
+      "description": [
+        "Établis une base"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: RED_BED\n",
       "order": 5,
       "challengeType": "ISLAND_TYPE",
@@ -477,7 +495,9 @@
       "uniqueId": "fisher",
       "friendlyName": "Pêcheur",
       "deployed": true,
-      "description": "Pêche 10 morues",
+      "description": [
+        "Pêche 10 morues"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: COD\n",
       "order": 6,
       "challengeType": "INVENTORY_TYPE",
@@ -564,7 +584,9 @@
       "uniqueId": "shell_harvester",
       "friendlyName": "Collecteur de coquilles",
       "deployed": true,
-      "description": "Collecte 5 écailles de carapace de tortue",
+      "description": [
+        "Collecte 5 écailles de carapace de tortue"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: TURTLE_HELMET\n",
       "order": -1,
       "challengeType": "INVENTORY_TYPE",
@@ -607,7 +629,9 @@
       "uniqueId": "swim_meet",
       "friendlyName": "Rencontre de natation",
       "deployed": true,
-      "description": "Fais la fête avec tes nouveaux « amis » !",
+      "description": [
+        "Fais la fête avec tes nouveaux « amis » !"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: PLAYER_HEAD\n",
       "order": -1,
       "challengeType": "ISLAND_TYPE",
@@ -700,7 +724,9 @@
       "uniqueId": "dark_food",
       "friendlyName": "Nourriture sombre",
       "deployed": true,
-      "description": "Prépare une soupe aux champignons !",
+      "description": [
+        "Prépare une soupe aux champignons !"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: MUSHROOM_STEW\n",
       "order": 1,
       "challengeType": "INVENTORY_TYPE",
@@ -758,7 +784,9 @@
       "uniqueId": "guardian_fighter",
       "friendlyName": "Chasseur de gardiens",
       "deployed": true,
-      "description": "Défais 3 gardiens",
+      "description": [
+        "Défais 3 gardiens"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: PRISMARINE\n",
       "order": 2,
       "challengeType": "STATISTIC_TYPE",
@@ -808,7 +836,9 @@
       "uniqueId": "underwater_farmer",
       "friendlyName": "Fermier sous-marin",
       "deployed": true,
-      "description": "Cultive et récolte des cornichons de mer !",
+      "description": [
+        "Cultive et récolte des cornichons de mer !"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: SEA_PICKLE\n",
       "order": 3,
       "challengeType": "INVENTORY_TYPE",
@@ -860,7 +890,9 @@
       "uniqueId": "dryworld_hunter",
       "friendlyName": "Chasseur du monde sec",
       "deployed": true,
-      "description": "Tue 10 creepers, zombies et squelettes",
+      "description": [
+        "Tue 10 creepers, zombies et squelettes"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: IRON_SWORD\n",
       "order": 4,
       "challengeType": "STATISTIC_TYPE",
@@ -924,7 +956,9 @@
       "uniqueId": "abyssal_treasure",
       "friendlyName": "Phénomène naturel",
       "deployed": true,
-      "description": "Fais recouvrir au moins 1 bloc de ton royaume par de la neige !",
+      "description": [
+        "Fais recouvrir au moins 1 bloc de ton royaume par de la neige !"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: SNOW\n",
       "order": -1,
       "challengeType": "ISLAND_TYPE",
@@ -971,7 +1005,9 @@
       "uniqueId": "conch_collector",
       "friendlyName": "Collecteur de conques",
       "deployed": true,
-      "description": "Trouve et réunis 5 coquilles de nautile",
+      "description": [
+        "Trouve et réunis 5 coquilles de nautile"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: NAUTILUS_SHELL\n",
       "order": -1,
       "challengeType": "INVENTORY_TYPE",
@@ -1012,7 +1048,9 @@
       "uniqueId": "conduit_crafter",
       "friendlyName": "Artisan des conduits",
       "deployed": true,
-      "description": "Fabrique et active un conduit",
+      "description": [
+        "Fabrique et active un conduit"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: CONDUIT\n",
       "order": -1,
       "challengeType": "ISLAND_TYPE",
@@ -1058,7 +1096,9 @@
       "uniqueId": "sea_lantern_artisan",
       "friendlyName": "Artisan des lanternes marines",
       "deployed": true,
-      "description": "Fabrique 16 lanternes marines",
+      "description": [
+        "Fabrique 16 lanternes marines"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: SEA_LANTERN\n",
       "order": -1,
       "challengeType": "INVENTORY_TYPE",
@@ -1099,7 +1139,9 @@
       "uniqueId": "swimmer",
       "friendlyName": "Le baiser de Poséidon",
       "deployed": true,
-      "description": "Nage 10 000 blocs",
+      "description": [
+        "Nage 10 000 blocs"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: LIGHT_BLUE_GLAZED_TERRACOTTA\n",
       "order": -1,
       "challengeType": "STATISTIC_TYPE",
@@ -1151,7 +1193,9 @@
       "uniqueId": "trawler",
       "friendlyName": "Chalutier",
       "deployed": true,
-      "description": "Pêche 50 poissons",
+      "description": [
+        "Pêche 50 poissons"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: COD\n",
       "order": -1,
       "challengeType": "STATISTIC_TYPE",
@@ -1203,7 +1247,9 @@
       "uniqueId": "trial_step",
       "friendlyName": "Pas d'épreuve",
       "deployed": true,
-      "description": "Entre dans une chambre d'épreuve",
+      "description": [
+        "Entre dans une chambre d'épreuve"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: TRIAL_KEY\n",
       "order": -1,
       "challengeType": "OTHER_TYPE",
@@ -1249,7 +1295,9 @@
       "uniqueId": "trident_wielder",
       "friendlyName": "Porteur du trident",
       "deployed": true,
-      "description": "Élimine 10 noyés de ton royaume",
+      "description": [
+        "Élimine 10 noyés de ton royaume"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: TRIDENT\n",
       "order": -1,
       "challengeType": "STATISTIC_TYPE",
@@ -1346,7 +1394,9 @@
       "uniqueId": "my_precious",
       "friendlyName": "Mon précieux",
       "deployed": true,
-      "description": "Quelques objets en fer",
+      "description": [
+        "Quelques objets en fer"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: POPPY\n",
       "order": -1,
       "challengeType": "ISLAND_TYPE",
@@ -1396,7 +1446,9 @@
       "uniqueId": "nether_swimmer",
       "friendlyName": "Pionnier",
       "deployed": true,
-      "description": "Fabrique une boussole et une horloge, voyage dans le Nether et ramasse une larme de ghast et quelques blocs",
+      "description": [
+        "Fabrique une boussole et une horloge, voyage dans le Nether et ramasse une larme de ghast et quelques blocs"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: POWERED_RAIL\n",
       "order": -1,
       "challengeType": "INVENTORY_TYPE",
@@ -1444,7 +1496,9 @@
       "uniqueId": "sea_potions",
       "friendlyName": "Potions marines",
       "deployed": true,
-      "description": "Brasse quelques potions",
+      "description": [
+        "Brasse quelques potions"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: POTION\n  meta:\n    ==: ItemMeta\n    meta-type: POTION\n    potion-type: minecraft:harming\n",
       "order": -1,
       "challengeType": "INVENTORY_TYPE",
@@ -1494,7 +1548,9 @@
       "uniqueId": "underwater_empire",
       "friendlyName": "Empire sous-marin",
       "deployed": true,
-      "description": "Construis un empire sous-marin avec au moins 64 blocs de verre",
+      "description": [
+        "Construis un empire sous-marin avec au moins 64 blocs de verre"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: GLASS\n",
       "order": -1,
       "challengeType": "ISLAND_TYPE",
@@ -1560,7 +1616,9 @@
       "uniqueId": "guardian_commander",
       "friendlyName": "Commandant des gardiens",
       "deployed": true,
-      "description": "Défais 20 gardiens anciens",
+      "description": [
+        "Défais 20 gardiens anciens"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: PRISMARINE_BRICKS\n",
       "order": -1,
       "challengeType": "STATISTIC_TYPE",
@@ -1620,7 +1678,9 @@
       "uniqueId": "statistic_challenge",
       "friendlyName": "L'héritage de Poséidon",
       "deployed": true,
-      "description": "Fabrique une balise",
+      "description": [
+        "Fabrique une balise"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: BEACON\n",
       "order": -1,
       "challengeType": "STATISTIC_TYPE",
@@ -1670,7 +1730,9 @@
       "uniqueId": "ttt",
       "friendlyName": "Légende des coraux",
       "deployed": true,
-      "description": "Construis une immense structure de récif corallien avec 200 blocs de corail",
+      "description": [
+        "Construis une immense structure de récif corallien avec 200 blocs de corail"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: BRAIN_CORAL\n",
       "order": -1,
       "challengeType": "ISLAND_TYPE",

--- a/challenges/library/poseidon-ru.json
+++ b/challenges/library/poseidon-ru.json
@@ -4,7 +4,9 @@
       "uniqueId": "opportunity_knocks",
       "friendlyName": "Удача стучится в дверь",
       "deployed": true,
-      "description": "Эй! Странствующий торговец! Быстро выполни это задание!",
+      "description": [
+        "Эй! Странствующий торговец! Быстро выполни это задание!"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: RED_CARPET\n",
       "order": -1,
       "challengeType": "ISLAND_TYPE",
@@ -50,7 +52,9 @@
       "uniqueId": "adv",
       "friendlyName": "Выбросить",
       "deployed": true,
-      "description": "Выполни достижение «Выбросить»",
+      "description": [
+        "Выполни достижение «Выбросить»"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: TRIDENT\n",
       "order": -1,
       "challengeType": "OTHER_TYPE",
@@ -97,7 +101,9 @@
       "uniqueId": "kelp_jerky",
       "friendlyName": "Вяленая морская капуста",
       "deployed": true,
-      "description": "Создай 5 пачек сушёной морской капусты",
+      "description": [
+        "Создай 5 пачек сушёной морской капусты"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: DRIED_KELP_BLOCK\n",
       "order": -1,
       "challengeType": "INVENTORY_TYPE",
@@ -141,7 +147,9 @@
       "uniqueId": "squid_hunter",
       "friendlyName": "Море и суша",
       "deployed": true,
-      "description": "Уничтожь кальмаров и тропических рыб",
+      "description": [
+        "Уничтожь кальмаров и тропических рыб"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: TROPICAL_FISH\n",
       "order": -1,
       "challengeType": "STATISTIC_TYPE",
@@ -197,7 +205,9 @@
       "uniqueId": "treasure_hunter",
       "friendlyName": "Спать с рыбами",
       "deployed": true,
-      "description": "Поспи в кровати",
+      "description": [
+        "Поспи в кровати"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: GREEN_BED\n",
       "order": -1,
       "challengeType": "STATISTIC_TYPE",
@@ -248,7 +258,9 @@
       "uniqueId": "kelp_harvester",
       "friendlyName": "Сборщик морской капусты",
       "deployed": true,
-      "description": "Собери 50 единиц морской капусты",
+      "description": [
+        "Собери 50 единиц морской капусты"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: KELP\n",
       "order": 1,
       "challengeType": "INVENTORY_TYPE",
@@ -291,7 +303,9 @@
       "uniqueId": "seagrass_farmer",
       "friendlyName": "Фермер морской травы",
       "deployed": true,
-      "description": "Собери морскую траву",
+      "description": [
+        "Собери морскую траву"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: SEAGRASS\n",
       "order": 2,
       "challengeType": "INVENTORY_TYPE",
@@ -382,7 +396,9 @@
       "uniqueId": "realm_builder",
       "friendlyName": "Строитель королевства",
       "deployed": true,
-      "description": "Прокачай своё королевство до уровня 10 (/[label] level)",
+      "description": [
+        "Прокачай своё королевство до уровня 10 (/[label] level)"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: BRICKS\n",
       "order": 4,
       "challengeType": "OTHER_TYPE",
@@ -425,7 +441,9 @@
       "uniqueId": "sea_sculptor",
       "friendlyName": "Укрытие",
       "deployed": true,
-      "description": "Построй базу",
+      "description": [
+        "Построй базу"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: RED_BED\n",
       "order": 5,
       "challengeType": "ISLAND_TYPE",
@@ -477,7 +495,9 @@
       "uniqueId": "fisher",
       "friendlyName": "Рыбак",
       "deployed": true,
-      "description": "Поймай 10 трески",
+      "description": [
+        "Поймай 10 трески"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: COD\n",
       "order": 6,
       "challengeType": "INVENTORY_TYPE",
@@ -564,7 +584,9 @@
       "uniqueId": "shell_harvester",
       "friendlyName": "Сборщик раковин",
       "deployed": true,
-      "description": "Собери 5 чешуек черепашьего панциря",
+      "description": [
+        "Собери 5 чешуек черепашьего панциря"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: TURTLE_HELMET\n",
       "order": -1,
       "challengeType": "INVENTORY_TYPE",
@@ -607,7 +629,9 @@
       "uniqueId": "swim_meet",
       "friendlyName": "Заплыв",
       "deployed": true,
-      "description": "Устрой вечеринку с новыми «друзьями»!",
+      "description": [
+        "Устрой вечеринку с новыми «друзьями»!"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: PLAYER_HEAD\n",
       "order": -1,
       "challengeType": "ISLAND_TYPE",
@@ -700,7 +724,9 @@
       "uniqueId": "dark_food",
       "friendlyName": "Тёмная еда",
       "deployed": true,
-      "description": "Приготовь грибной суп!",
+      "description": [
+        "Приготовь грибной суп!"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: MUSHROOM_STEW\n",
       "order": 1,
       "challengeType": "INVENTORY_TYPE",
@@ -758,7 +784,9 @@
       "uniqueId": "guardian_fighter",
       "friendlyName": "Охотник на стражников",
       "deployed": true,
-      "description": "Победи 3 стражников",
+      "description": [
+        "Победи 3 стражников"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: PRISMARINE\n",
       "order": 2,
       "challengeType": "STATISTIC_TYPE",
@@ -808,7 +836,9 @@
       "uniqueId": "underwater_farmer",
       "friendlyName": "Подводный фермер",
       "deployed": true,
-      "description": "Выращивай и собирай морские огурцы!",
+      "description": [
+        "Выращивай и собирай морские огурцы!"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: SEA_PICKLE\n",
       "order": 3,
       "challengeType": "INVENTORY_TYPE",
@@ -860,7 +890,9 @@
       "uniqueId": "dryworld_hunter",
       "friendlyName": "Охотник на суше",
       "deployed": true,
-      "description": "Убей 10 криперов, зомби и скелетов",
+      "description": [
+        "Убей 10 криперов, зомби и скелетов"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: IRON_SWORD\n",
       "order": 4,
       "challengeType": "STATISTIC_TYPE",
@@ -924,7 +956,9 @@
       "uniqueId": "abyssal_treasure",
       "friendlyName": "Природная аномалия",
       "deployed": true,
-      "description": "Пусть хотя бы 1 блок твоего королевства будет покрыт снегом!",
+      "description": [
+        "Пусть хотя бы 1 блок твоего королевства будет покрыт снегом!"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: SNOW\n",
       "order": -1,
       "challengeType": "ISLAND_TYPE",
@@ -971,7 +1005,9 @@
       "uniqueId": "conch_collector",
       "friendlyName": "Собиратель раковин nautilus",
       "deployed": true,
-      "description": "Найди и собери 5 раковин наутилуса",
+      "description": [
+        "Найди и собери 5 раковин наутилуса"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: NAUTILUS_SHELL\n",
       "order": -1,
       "challengeType": "INVENTORY_TYPE",
@@ -1012,7 +1048,9 @@
       "uniqueId": "conduit_crafter",
       "friendlyName": "Мастер кондуитов",
       "deployed": true,
-      "description": "Создай и активируй кондуит",
+      "description": [
+        "Создай и активируй кондуит"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: CONDUIT\n",
       "order": -1,
       "challengeType": "ISLAND_TYPE",
@@ -1058,7 +1096,9 @@
       "uniqueId": "sea_lantern_artisan",
       "friendlyName": "Мастер морских фонарей",
       "deployed": true,
-      "description": "Создай 16 морских фонарей",
+      "description": [
+        "Создай 16 морских фонарей"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: SEA_LANTERN\n",
       "order": -1,
       "challengeType": "INVENTORY_TYPE",
@@ -1099,7 +1139,9 @@
       "uniqueId": "swimmer",
       "friendlyName": "Поцелуй Посейдона",
       "deployed": true,
-      "description": "Проплыви 10 000 блоков",
+      "description": [
+        "Проплыви 10 000 блоков"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: LIGHT_BLUE_GLAZED_TERRACOTTA\n",
       "order": -1,
       "challengeType": "STATISTIC_TYPE",
@@ -1151,7 +1193,9 @@
       "uniqueId": "trawler",
       "friendlyName": "Траулер",
       "deployed": true,
-      "description": "Поймай 50 рыб",
+      "description": [
+        "Поймай 50 рыб"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: COD\n",
       "order": -1,
       "challengeType": "STATISTIC_TYPE",
@@ -1203,7 +1247,9 @@
       "uniqueId": "trial_step",
       "friendlyName": "Шаг испытания",
       "deployed": true,
-      "description": "Войди в Испытательную камеру",
+      "description": [
+        "Войди в Испытательную камеру"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: TRIAL_KEY\n",
       "order": -1,
       "challengeType": "OTHER_TYPE",
@@ -1249,7 +1295,9 @@
       "uniqueId": "trident_wielder",
       "friendlyName": "Владелец трезубца",
       "deployed": true,
-      "description": "Устрани 10 утопленников из своего королевства",
+      "description": [
+        "Устрани 10 утопленников из своего королевства"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: TRIDENT\n",
       "order": -1,
       "challengeType": "STATISTIC_TYPE",
@@ -1346,7 +1394,9 @@
       "uniqueId": "my_precious",
       "friendlyName": "Моя прелесть",
       "deployed": true,
-      "description": "Несколько железных вещей",
+      "description": [
+        "Несколько железных вещей"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: POPPY\n",
       "order": -1,
       "challengeType": "ISLAND_TYPE",
@@ -1396,7 +1446,9 @@
       "uniqueId": "nether_swimmer",
       "friendlyName": "Первопроходец",
       "deployed": true,
-      "description": "Создай компас и часы, отправься в Незер и подбери слезу гаста и несколько блоков",
+      "description": [
+        "Создай компас и часы, отправься в Незер и подбери слезу гаста и несколько блоков"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: POWERED_RAIL\n",
       "order": -1,
       "challengeType": "INVENTORY_TYPE",
@@ -1444,7 +1496,9 @@
       "uniqueId": "sea_potions",
       "friendlyName": "Морские зелья",
       "deployed": true,
-      "description": "Сваривy несколько зелий",
+      "description": [
+        "Сваривy несколько зелий"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: POTION\n  meta:\n    ==: ItemMeta\n    meta-type: POTION\n    potion-type: minecraft:harming\n",
       "order": -1,
       "challengeType": "INVENTORY_TYPE",
@@ -1494,7 +1548,9 @@
       "uniqueId": "underwater_empire",
       "friendlyName": "Подводная империя",
       "deployed": true,
-      "description": "Построй подводную империю из не менее чем 64 стеклянных блоков",
+      "description": [
+        "Построй подводную империю из не менее чем 64 стеклянных блоков"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: GLASS\n",
       "order": -1,
       "challengeType": "ISLAND_TYPE",
@@ -1560,7 +1616,9 @@
       "uniqueId": "guardian_commander",
       "friendlyName": "Командир стражников",
       "deployed": true,
-      "description": "Победи 20 старших стражников",
+      "description": [
+        "Победи 20 старших стражников"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: PRISMARINE_BRICKS\n",
       "order": -1,
       "challengeType": "STATISTIC_TYPE",
@@ -1620,7 +1678,9 @@
       "uniqueId": "statistic_challenge",
       "friendlyName": "Наследие Посейдона",
       "deployed": true,
-      "description": "Создай маяк",
+      "description": [
+        "Создай маяк"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: BEACON\n",
       "order": -1,
       "challengeType": "STATISTIC_TYPE",
@@ -1670,7 +1730,9 @@
       "uniqueId": "ttt",
       "friendlyName": "Легенда кораллов",
       "deployed": true,
-      "description": "Построй огромную коралловую конструкцию из 200 коралловых блоков",
+      "description": [
+        "Построй огромную коралловую конструкцию из 200 коралловых блоков"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: BRAIN_CORAL\n",
       "order": -1,
       "challengeType": "ISLAND_TYPE",

--- a/challenges/library/poseidon-zh-CN.json
+++ b/challenges/library/poseidon-zh-CN.json
@@ -4,7 +4,9 @@
       "uniqueId": "opportunity_knocks",
       "friendlyName": "机会来临",
       "deployed": true,
-      "description": "嘿！一个流浪商人！快完成这个挑战！",
+      "description": [
+        "嘿！一个流浪商人！快完成这个挑战！"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: RED_CARPET\n",
       "order": -1,
       "challengeType": "ISLAND_TYPE",
@@ -50,7 +52,9 @@
       "uniqueId": "adv",
       "friendlyName": "随手丢弃",
       "deployed": true,
-      "description": "完成\"随手丢弃的笑话\"进度",
+      "description": [
+        "完成\"随手丢弃的笑话\"进度"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: TRIDENT\n",
       "order": -1,
       "challengeType": "OTHER_TYPE",
@@ -97,7 +101,9 @@
       "uniqueId": "kelp_jerky",
       "friendlyName": "海带干",
       "deployed": true,
-      "description": "制作5包干海带",
+      "description": [
+        "制作5包干海带"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: DRIED_KELP_BLOCK\n",
       "order": -1,
       "challengeType": "INVENTORY_TYPE",
@@ -141,7 +147,9 @@
       "uniqueId": "squid_hunter",
       "friendlyName": "海陆大餐",
       "deployed": true,
-      "description": "猎杀鱿鱼和热带鱼",
+      "description": [
+        "猎杀鱿鱼和热带鱼"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: TROPICAL_FISH\n",
       "order": -1,
       "challengeType": "STATISTIC_TYPE",
@@ -197,7 +205,9 @@
       "uniqueId": "treasure_hunter",
       "friendlyName": "与鱼共眠",
       "deployed": true,
-      "description": "在床上睡觉",
+      "description": [
+        "在床上睡觉"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: GREEN_BED\n",
       "order": -1,
       "challengeType": "STATISTIC_TYPE",
@@ -248,7 +258,9 @@
       "uniqueId": "kelp_harvester",
       "friendlyName": "海带收割者",
       "deployed": true,
-      "description": "收获50根海带",
+      "description": [
+        "收获50根海带"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: KELP\n",
       "order": 1,
       "challengeType": "INVENTORY_TYPE",
@@ -291,7 +303,9 @@
       "uniqueId": "seagrass_farmer",
       "friendlyName": "海草农夫",
       "deployed": true,
-      "description": "收集海草",
+      "description": [
+        "收集海草"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: SEAGRASS\n",
       "order": 2,
       "challengeType": "INVENTORY_TYPE",
@@ -382,7 +396,9 @@
       "uniqueId": "realm_builder",
       "friendlyName": "领域建造者",
       "deployed": true,
-      "description": "将你的领域升至10级 (/[label] level)",
+      "description": [
+        "将你的领域升至10级 (/[label] level)"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: BRICKS\n",
       "order": 4,
       "challengeType": "OTHER_TYPE",
@@ -425,7 +441,9 @@
       "uniqueId": "sea_sculptor",
       "friendlyName": "隐蔽之所",
       "deployed": true,
-      "description": "建立一个家庭基地",
+      "description": [
+        "建立一个家庭基地"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: RED_BED\n",
       "order": 5,
       "challengeType": "ISLAND_TYPE",
@@ -477,7 +495,9 @@
       "uniqueId": "fisher",
       "friendlyName": "渔夫",
       "deployed": true,
-      "description": "钓取10条鳕鱼",
+      "description": [
+        "钓取10条鳕鱼"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: COD\n",
       "order": 6,
       "challengeType": "INVENTORY_TYPE",
@@ -564,7 +584,9 @@
       "uniqueId": "shell_harvester",
       "friendlyName": "贝壳收集者",
       "deployed": true,
-      "description": "收集5块龟壳碎片",
+      "description": [
+        "收集5块龟壳碎片"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: TURTLE_HELMET\n",
       "order": -1,
       "challengeType": "INVENTORY_TYPE",
@@ -607,7 +629,9 @@
       "uniqueId": "swim_meet",
       "friendlyName": "游泳聚会",
       "deployed": true,
-      "description": "和你的新\"朋友们\"开派对！",
+      "description": [
+        "和你的新\"朋友们\"开派对！"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: PLAYER_HEAD\n",
       "order": -1,
       "challengeType": "ISLAND_TYPE",
@@ -700,7 +724,9 @@
       "uniqueId": "dark_food",
       "friendlyName": "黑暗食物",
       "deployed": true,
-      "description": "制作蘑菇炖汤！",
+      "description": [
+        "制作蘑菇炖汤！"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: MUSHROOM_STEW\n",
       "order": 1,
       "challengeType": "INVENTORY_TYPE",
@@ -758,7 +784,9 @@
       "uniqueId": "guardian_fighter",
       "friendlyName": "守卫战士",
       "deployed": true,
-      "description": "击败3只守卫者",
+      "description": [
+        "击败3只守卫者"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: PRISMARINE\n",
       "order": 2,
       "challengeType": "STATISTIC_TYPE",
@@ -808,7 +836,9 @@
       "uniqueId": "underwater_farmer",
       "friendlyName": "水下农夫",
       "deployed": true,
-      "description": "种植并收获海泡菜！",
+      "description": [
+        "种植并收获海泡菜！"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: SEA_PICKLE\n",
       "order": 3,
       "challengeType": "INVENTORY_TYPE",
@@ -860,7 +890,9 @@
       "uniqueId": "dryworld_hunter",
       "friendlyName": "旱地猎人",
       "deployed": true,
-      "description": "击杀10只爬行者、僵尸和骷髅",
+      "description": [
+        "击杀10只爬行者、僵尸和骷髅"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: IRON_SWORD\n",
       "order": 4,
       "challengeType": "STATISTIC_TYPE",
@@ -924,7 +956,9 @@
       "uniqueId": "abyssal_treasure",
       "friendlyName": "自然奇迹",
       "deployed": true,
-      "description": "让你的领域至少有1格被雪覆盖！",
+      "description": [
+        "让你的领域至少有1格被雪覆盖！"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: SNOW\n",
       "order": -1,
       "challengeType": "ISLAND_TYPE",
@@ -971,7 +1005,9 @@
       "uniqueId": "conch_collector",
       "friendlyName": "海螺收藏家",
       "deployed": true,
-      "description": "找到并收集5个鹦鹉螺壳",
+      "description": [
+        "找到并收集5个鹦鹉螺壳"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: NAUTILUS_SHELL\n",
       "order": -1,
       "challengeType": "INVENTORY_TYPE",
@@ -1012,7 +1048,9 @@
       "uniqueId": "conduit_crafter",
       "friendlyName": "导管工匠",
       "deployed": true,
-      "description": "制作并激活一个导管",
+      "description": [
+        "制作并激活一个导管"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: CONDUIT\n",
       "order": -1,
       "challengeType": "ISLAND_TYPE",
@@ -1058,7 +1096,9 @@
       "uniqueId": "sea_lantern_artisan",
       "friendlyName": "海晶灯工匠",
       "deployed": true,
-      "description": "制作16个海晶灯",
+      "description": [
+        "制作16个海晶灯"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: SEA_LANTERN\n",
       "order": -1,
       "challengeType": "INVENTORY_TYPE",
@@ -1099,7 +1139,9 @@
       "uniqueId": "swimmer",
       "friendlyName": "波塞冬之吻",
       "deployed": true,
-      "description": "游泳10000格",
+      "description": [
+        "游泳10000格"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: LIGHT_BLUE_GLAZED_TERRACOTTA\n",
       "order": -1,
       "challengeType": "STATISTIC_TYPE",
@@ -1151,7 +1193,9 @@
       "uniqueId": "trawler",
       "friendlyName": "拖网渔船",
       "deployed": true,
-      "description": "钓取50条鱼",
+      "description": [
+        "钓取50条鱼"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: COD\n",
       "order": -1,
       "challengeType": "STATISTIC_TYPE",
@@ -1203,7 +1247,9 @@
       "uniqueId": "trial_step",
       "friendlyName": "试炼之步",
       "deployed": true,
-      "description": "进入一个试炼密室",
+      "description": [
+        "进入一个试炼密室"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: TRIAL_KEY\n",
       "order": -1,
       "challengeType": "OTHER_TYPE",
@@ -1249,7 +1295,9 @@
       "uniqueId": "trident_wielder",
       "friendlyName": "三叉戟使者",
       "deployed": true,
-      "description": "从你的领域中清除10只溺尸",
+      "description": [
+        "从你的领域中清除10只溺尸"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: TRIDENT\n",
       "order": -1,
       "challengeType": "STATISTIC_TYPE",
@@ -1346,7 +1394,9 @@
       "uniqueId": "my_precious",
       "friendlyName": "我的宝贝",
       "deployed": true,
-      "description": "一些铁制品",
+      "description": [
+        "一些铁制品"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: POPPY\n",
       "order": -1,
       "challengeType": "ISLAND_TYPE",
@@ -1396,7 +1446,9 @@
       "uniqueId": "nether_swimmer",
       "friendlyName": "先驱者",
       "deployed": true,
-      "description": "制作指南针、时钟，前往地狱并拾取恶魂之泪和一些方块",
+      "description": [
+        "制作指南针、时钟，前往地狱并拾取恶魂之泪和一些方块"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: POWERED_RAIL\n",
       "order": -1,
       "challengeType": "INVENTORY_TYPE",
@@ -1444,7 +1496,9 @@
       "uniqueId": "sea_potions",
       "friendlyName": "海洋药水",
       "deployed": true,
-      "description": "酿造一些药水",
+      "description": [
+        "酿造一些药水"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: POTION\n  meta:\n    ==: ItemMeta\n    meta-type: POTION\n    potion-type: minecraft:harming\n",
       "order": -1,
       "challengeType": "INVENTORY_TYPE",
@@ -1494,7 +1548,9 @@
       "uniqueId": "underwater_empire",
       "friendlyName": "水下帝国",
       "deployed": true,
-      "description": "用至少64块玻璃建造水下帝国",
+      "description": [
+        "用至少64块玻璃建造水下帝国"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: GLASS\n",
       "order": -1,
       "challengeType": "ISLAND_TYPE",
@@ -1560,7 +1616,9 @@
       "uniqueId": "guardian_commander",
       "friendlyName": "守卫指挥官",
       "deployed": true,
-      "description": "击败20只远古守卫者",
+      "description": [
+        "击败20只远古守卫者"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: PRISMARINE_BRICKS\n",
       "order": -1,
       "challengeType": "STATISTIC_TYPE",
@@ -1620,7 +1678,9 @@
       "uniqueId": "statistic_challenge",
       "friendlyName": "波塞冬的遗产",
       "deployed": true,
-      "description": "制作一个信标",
+      "description": [
+        "制作一个信标"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: BEACON\n",
       "order": -1,
       "challengeType": "STATISTIC_TYPE",
@@ -1670,7 +1730,9 @@
       "uniqueId": "ttt",
       "friendlyName": "珊瑚传奇",
       "deployed": true,
-      "description": "用200个珊瑚方块建造一座宏伟的珊瑚礁结构",
+      "description": [
+        "用200个珊瑚方块建造一座宏伟的珊瑚礁结构"
+      ],
       "icon": "is:\n  ==: org.bukkit.inventory.ItemStack\n  v: 4189\n  type: BRAIN_CORAL\n",
       "order": -1,
       "challengeType": "ISLAND_TYPE",


### PR DESCRIPTION
## Summary

The five translated Poseidon library files stored `description` as a single string instead of a list of strings, while the Challenges addon's `Challenge.description` is `List<String>`. Gson rejected the payload with:

```
JsonSyntaxException: Expected BEGIN_ARRAY but was STRING
  at line 7 column 23 path $.challengeList[0].description
```

`ChallengesImportManager.loadDownloadedChallenges` swallowed the error silently — admins saw "successfully imported" but ended up with zero challenges and a stacktrace buried in the server log.

This wraps each string description in a single-element list to match `poseidon.json` and every other locale file in the catalog.

## Affected files

- `poseidon-de.json` (31 entries)
- `poseidon-es.json` (31 entries)
- `poseidon-fr.json` (31 entries)
- `poseidon-ru.json` (31 entries)
- `poseidon-zh-CN.json` (31 entries)

All other library files (acidisland, skyblock, default, askyblock-challenges) were already correct.

## History

Briefly pushed directly to `master` then reverted to investigate a separate report that the web library icon may have stopped appearing in the GUI after the change. Holding here as a PR pending that check.

## Test plan

- [ ] On a fresh server, open `/[gamemode] admin challenges`, click the web library icon
- [ ] Select the Poseidon zh-CN entry, confirm import — chat should show `Adding new object` per challenge
- [ ] `/[gamemode] challenges` lists the imported challenges (no more "no challenges available" message)
- [ ] Server console has no `JsonSyntaxException` from the Challenges addon
- [ ] Repeat for de, es, fr, ru variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)